### PR TITLE
Correction of the heading controller calculation

### DIFF
--- a/missions/integrationTests/test_pController_iSaucisse_uJoystick.moos
+++ b/missions/integrationTests/test_pController_iSaucisse_uJoystick.moos
@@ -12,7 +12,7 @@ ProcessConfig = ANTLER
 {
   MSBetweenLaunches = 200
   Run = MOOSDB        @ NewConsole = false
-  Run = iKeller       @ NewConsole = true
+  Run = iXSensINS     @ NewConsole = true
   Run = uJoystick     @ NewConsole = false
   Run = iSaucisse     @ NewConsole = true
   Run = pController   @ NewConsole = true
@@ -21,21 +21,27 @@ ProcessConfig = ANTLER
 
 }
 
-ProcessConfig = iKeller
+
+XSENSINS_SERIAL_PORT = /dev/ttyUSB0
+
+ProcessConfig = iXSensINS
 {
   AppTick   = 4
   CommsTick = 4
 
-  SERIAL_PORT_NAME = /dev/ttyUSB0
-  MAX_RETRIES = 10
+  UART_BAUD_RATE = 115200
+
+  // magnetic declination for Piombino (2°E)
+  YAW_DECLINATION = -2
 }
+
 
 ProcessConfig = uJoystick
 {
    AppTick   = 4
    CommsTick = 4
    
-   DEVICE_NAME = /dev/input/js0
+   DEVICE_NAME = /dev/input/js1
 
    INCREMENT = false
    SCALE = 100
@@ -106,4 +112,6 @@ ProcessConfig = uMACView
 {
   AppTick   = 4
   CommsTick = 4
+
+
 }

--- a/src/app/iSaucisse/iSaucisse.xml
+++ b/src/app/iSaucisse/iSaucisse.xml
@@ -76,7 +76,7 @@
               <moosvar>
                  <varname>DESIRED_RUDDER</varname>
                  <vartype>double</vartype>
-                 <varinfo>Desired roll motion [-1;1]. Tipically, this variable is sent by uJoystick. This value is used to drive the thrusters only when the Operation Mode is in "MANUAL" or "DEPTH_CONTROL_ONLY" mode. In other modes this value is ignored. This value is intended to move the vehicle in roll motion. </varinfo>
+                 <varinfo>Desired yaw motion [-1;1]. Tipically, this variable is sent by uJoystick. This value is used to drive the thrusters only when the Operation Mode is in "MANUAL" or "DEPTH_CONTROL_ONLY" mode. In other modes this value is ignored. This value is intended to move the vehicle in yaw motion. </varinfo>
               </moosvar>
 
               <moosvar>
@@ -152,7 +152,7 @@
               <moosvar>
                  <varname>OPERATION_MODE</varname>
                  <vartype>string</vartype>
-                 <varinfo>"MANUAL": The vehicle is operated manually (by uJoystick), receiving the DESIRED_THRUSTER, DESIRED_RUDDER and DESIRED_ELEVATOR variables. "SEMI-AUTONOMUS" and "AUTONOMUS": The thrusters are controlled by the pController by the use of variables FX_FORWARD_FORCE, FR_ROTATIONAL_FORCE, FZ_VERTICAL_FORCE. "DEPTH_CONTROL_ONLY": in this mode the depth is controlled by the pController and the forward and roll motion are controlled by the uJoystick. </varinfo>
+                 <varinfo>"MANUAL": The vehicle is operated manually (by uJoystick), receiving the DESIRED_THRUSTER, DESIRED_RUDDER and DESIRED_ELEVATOR variables. "SEMI-AUTONOMUS" and "AUTONOMUS": The thrusters are controlled by the pController by the use of variables FX_FORWARD_FORCE, FR_ROTATIONAL_FORCE, FZ_VERTICAL_FORCE. "DEPTH_CONTROL_ONLY": in this mode the depth is controlled by the pController and the forward and yaw motion are controlled by the uJoystick. </varinfo>
               </moosvar>
            </publications>
         </interface>

--- a/src/app/pController/Controller.cpp
+++ b/src/app/pController/Controller.cpp
@@ -67,7 +67,10 @@ bool Controller::OnNewMail(MOOSMSG_LIST &NewMail)
 
 
     else if(key == "IMU_YAW") 
-      actual_heading = msg.GetDouble();
+      //The IMU-YWA rate received from iXSensIMU is in interval [-180;180] 
+      //and the controller is intended to work with [0;360] values
+      actual_heading = msg.GetDouble() + 180; 
+
     else if(key == "KELLER_DEPTH") 
       actual_depth = msg.GetDouble();
 
@@ -129,13 +132,13 @@ bool Controller::Iterate()
     /** HEADING CONTROLLER */
 
       //calculate the error (actual heading - desired heading)
-      error_heading_rad = (actual_heading - desired_heading) * PI/180;
+      error_heading_rad = (actual_heading - desired_heading) * PI/180.0;
 
       //wrap the error into [-PI;PI]
-      error_heading_rad = -2*atan(tan(error_heading_degrees/2));
+      error_heading_rad = -2.0*atan(tan(error_heading_rad/2.0));
 
       //convert error to degress
-      error_heading_degrees = error_heading_rad *180/PI;
+      error_heading_degrees = error_heading_rad *180.0/PI;
 
       //check if the error is bigger than the min error parameter
       if(fabs(error_heading_degrees) > MIN_HEADING_ERROR)


### PR DESCRIPTION
The heading controller was intended to receive an actual heading in the interval of [0;360[ degrees , but the iXsens is sending and YAW_ANGLE in the interval [-181.2;180] degrees. pController was adapted to work with the iXsens intervals.
