### PR TITLE
On OSX (probably Linux too), cd $PWD won't work when path contains white spaces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ compiler:
  - gcc
 
 before_script:
+ - export curr_path=$PWD
+ - cd ..
  - svn co https://oceanai.mit.edu/svn/moos-ivp-aro/releases/moos-ivp-15.5 moos-ivp
  - cd moos-ivp
  - sudo apt-get install g++ subversion xterm cmake libfltk1.3-dev freeglut3-dev libpng12-dev libjpeg-dev libxft-dev libxinerama-dev libtiff4-dev
@@ -11,7 +13,7 @@ before_script:
  - ./build-ivp.sh
  - export PATH=$PATH:$PWD/bin
  - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/lib
- - cd ../
+ - cd "$curr_path"
 
 script:
  - ./build.sh

--- a/build.sh
+++ b/build.sh
@@ -40,4 +40,4 @@ cd build
 cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ../
 
 make ${CMD_LINE_ARGS}
-cd ${INVOCATION_ABS_DIR}
+cd "${INVOCATION_ABS_DIR}"


### PR DESCRIPTION
Had this problem on my computer.
