### PR TITLE
Casted ints to floats in parse.c. It now builds with gcc 5.4.0 on Ubuntu 16.04

### DIFF
--- a/src/app/interfaces/iGPS/lib_nmea/src/parse.c
+++ b/src/app/interfaces/iGPS/lib_nmea/src/parse.c
@@ -905,7 +905,7 @@ int nmea_parse_PRTI01(const char *s, const int len, bool has_checksum, nmeaPRTI0
     return 0;
   }
 
-  if (!isnan(pack->bottom_vx) && !isnan(pack->bottom_vy) && !isnan(pack->bottom_vz)) {
+  if (!isnan((float)pack->bottom_vx) && !isnan((float)pack->bottom_vy) && !isnan((float)pack->bottom_vz)) {
     nmea_INFO_set_present(&pack->present, RTI);
   }
 

--- a/src/app/interfaces/iPololu/iPololu.xml
+++ b/src/app/interfaces/iPololu/iPololu.xml
@@ -24,7 +24,7 @@
               <moosvar>
                  <varname>$(MOOSVAR_SUBSCRIPTION)</varname>
                  <vartype>double</vartype>
-                 <varinfo>set PWM value based on a ratio belonging to the set [-1;1]</varinfo>
+                 <varinfo>set PWM value based on a ratio belonging to the set [-100;100]</varinfo>
               </moosvar>
            </subscriptions>
            <publications>


### PR DESCRIPTION
I was getting this error when building:  
```$ src/parse.c:908:3: error: non-floating-point argument in call to function ‘__builtin_isnan’```

So I casted to float. I'm not familiar with C, so any criticisms are welcome.