### PR TITLE
[iRazorIMU] test didn't specify port correctly

### DIFF
--- a/tests/test_iRazorIMU.moos
+++ b/tests/test_iRazorIMU.moos
@@ -15,13 +15,12 @@ ProcessConfig = ANTLER
 
 //------------------------------------------------
 // iRazorIMU config block
-
-RAZORIMU_SERIAL_PORT = /dev/ttyUSB0
-
 ProcessConfig = iRazorIMU
 {
   AppTick   = 4
   CommsTick = 4
+
+  SERIAL_PORT = /dev/ttyUSB0
 
   MODE = ACC_MAG_GYR_CALIBRATED
   // MODE values:


### PR DESCRIPTION
For some reason [test_iRazorIMU.moos](https://github.com/ENSTABretagneRobotics/moos-ivp-enstabretagne/blob/master/tests/test_iRazorIMU.moos) specified the serial port outside the ProcessConfig block:
```
//------------------------------------------------
// iRazorIMU config block

RAZORIMU_SERIAL_PORT = /dev/ttyUSB0

ProcessConfig = iRazorIMU
{
  AppTick   = 4
  CommsTick = 4

  MODE = ACC_MAG_GYR_CALIBRATED
  // MODE values:
  //    YAW_PITCH_ROLL
  //    ACC_MAG_GYR_RAW
  //    ACC_MAG_GYR_CALIBRATED
}
```

The  [app itself](https://github.com/ENSTABretagneRobotics/moos-ivp-enstabretagne/blob/055f7be8ff09ae532dd5e0c4d40bf820ba020bb2/src/app/interfaces/iRazorIMU/RazorIMU.cpp#L125)  expects parameter `SERIAL_PORT` to be specified. 